### PR TITLE
Changed signed method to POST to GET

### DIFF
--- a/src/main/webapp/WEB-INF/upload/upload.html
+++ b/src/main/webapp/WEB-INF/upload/upload.html
@@ -45,8 +45,8 @@
 	UploadService.prototype.getSignedUrl = function(file) {
 		var defer = $.Deferred();
 		$.ajax({
-			url: "/upload/url",
-			type: "GET",
+			type: "POST",
+			url: "/upload",
 			data: { "name": file.name, "type": file.type },
 			success: defer.resolve,
 			error: defer.reject


### PR DESCRIPTION
Tomcat5以降GETパラメータのエンコードがISO8859-1になっているらしく
変更するにはserver.xmlに useBodyEncodingForURI="true"を追加する必要があるが
今回はwebapp-runnerを使っているため指定できないのでPOSTに変更

リクエストのURIによる振り分け処理も削除しました
